### PR TITLE
Fix validators public key aggregation

### DIFF
--- a/chain/listener/listener.go
+++ b/chain/listener/listener.go
@@ -119,6 +119,14 @@ func (l *listener) pollBlocks() error {
 				continue
 			}
 
+			// debugging
+
+			apk, err := l.valsAggr.GetAPKForBlock(latestBlock, uint8(l.cfg.ID), l.cfg.EpochSize)
+			if err != nil {
+				return err
+			}
+			log.Debug().Msgf("APK: %x", apk)
+
 			// Sleep if the difference is less than BlockDelay; (latest - current) < BlockDelay
 			if big.NewInt(0).Sub(latestBlock, currentBlock).Cmp(BlockDelay) == -1 {
 				time.Sleep(BlockRetryInterval)

--- a/chain/listener/listener.go
+++ b/chain/listener/listener.go
@@ -119,27 +119,6 @@ func (l *listener) pollBlocks() error {
 				continue
 			}
 
-			// debugging
-
-			blockData, err := l.client.BlockByNumber(context.Background(), latestBlock)
-			if err != nil {
-				return err
-			}
-
-			// fetch IstanbulExtra data by parsing block header
-			// https://github.com/celo-org/celo-blockchain/blob/master/core/types/istanbul.go#L128-L142
-			extra, err := types.ExtractIstanbulExtra(blockData.Header())
-			if err != nil {
-				return err
-			}
-
-			apk, err := l.valsAggr.GetAPKForBlock(latestBlock, uint8(l.cfg.ID), l.cfg.EpochSize, extra)
-			if err != nil {
-				return err
-			}
-
-			log.Debug().Msgf("APK: %x", apk)
-
 			// Sleep if the difference is less than BlockDelay; (latest - current) < BlockDelay
 			if big.NewInt(0).Sub(latestBlock, currentBlock).Cmp(BlockDelay) == -1 {
 				time.Sleep(BlockRetryInterval)

--- a/chain/listener/listener.go
+++ b/chain/listener/listener.go
@@ -126,6 +126,8 @@ func (l *listener) pollBlocks() error {
 				return err
 			}
 
+			// fetch IstanbulExtra data by parsing block header
+			// https://github.com/celo-org/celo-blockchain/blob/master/core/types/istanbul.go#L128-L142
 			extra, err := types.ExtractIstanbulExtra(blockData.Header())
 			if err != nil {
 				return err
@@ -135,6 +137,7 @@ func (l *listener) pollBlocks() error {
 			if err != nil {
 				return err
 			}
+
 			log.Debug().Msgf("APK: %x", apk)
 
 			// Sleep if the difference is less than BlockDelay; (latest - current) < BlockDelay

--- a/chain/listener/listener_test.go
+++ b/chain/listener/listener_test.go
@@ -317,10 +317,14 @@ func (s *ListenerTestSuite) TestGetDepositEventsAndProofsForBlockerERC20() {
 
 	destID := utils.ChainId(logs[0].Topics[1].Big().Uint64())
 	pk := []byte{0x1f}
-	s.validatorsAggregatorMock.EXPECT().GetAPKForBlock(gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte{0x1f}, nil)
 
 	// replace block with customized block to hold IstanbulExtra data
 	block := dummyBlockWithIstanbulExtra(123)
+
+	extra, err := types.ExtractIstanbulExtra(block.Header())
+	s.Nil(err)
+
+	s.validatorsAggregatorMock.EXPECT().GetAPKForBlock(gomock.Any(), gomock.Any(), gomock.Any(), extra).Return([]byte{0x1f}, nil)
 
 	s.clientMock.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
 
@@ -332,9 +336,6 @@ func (s *ListenerTestSuite) TestGetDepositEventsAndProofsForBlockerERC20() {
 	s.Nil(err)
 
 	proof, key, err := txtrie.RetrieveProof(trie, keyRlp)
-	s.Nil(err)
-
-	extra, err := types.ExtractIstanbulExtra(block.Header())
 	s.Nil(err)
 
 	rlpHeader, err := utils.RlpEncodeHeader(block.Header())
@@ -437,15 +438,16 @@ func (s *ListenerTestSuite) TestGetDepositEventsAndProofsForBlockerERC721() {
 
 	destID := utils.ChainId(logs[0].Topics[1].Big().Uint64())
 	pk := []byte{0x1f}
-	s.validatorsAggregatorMock.EXPECT().GetAPKForBlock(gomock.Any(), gomock.Any(), gomock.Any()).Return(pk, nil)
 
 	// replace block with customized block to hold IstanbulExtra data
 	block := dummyBlockWithIstanbulExtra(123)
 
-	s.clientMock.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
-
 	extra, err := types.ExtractIstanbulExtra(block.Header())
 	s.Nil(err)
+
+	s.validatorsAggregatorMock.EXPECT().GetAPKForBlock(gomock.Any(), gomock.Any(), gomock.Any(), extra).Return(pk, nil)
+
+	s.clientMock.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
 
 	rlpHeader, err := utils.RlpEncodeHeader(block.Header())
 	s.Nil(err)
@@ -532,15 +534,16 @@ func (s *ListenerTestSuite) TestGetDepositEventsAndProofsForBlockerGeneric() {
 
 	destID := utils.ChainId(logs[0].Topics[1].Big().Uint64())
 	pk := []byte{0x1f}
-	s.validatorsAggregatorMock.EXPECT().GetAPKForBlock(gomock.Any(), gomock.Any(), gomock.Any()).Return(pk, nil)
 
 	// replace block with customized block to hold IstanbulExtra data
 	block := dummyBlockWithIstanbulExtra(123)
 
-	s.clientMock.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
-
 	extra, err := types.ExtractIstanbulExtra(block.Header())
 	s.Nil(err)
+
+	s.validatorsAggregatorMock.EXPECT().GetAPKForBlock(gomock.Any(), gomock.Any(), gomock.Any(), extra).Return(pk, nil)
+
+	s.clientMock.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
 
 	rlpHeader, err := utils.RlpEncodeHeader(block.Header())
 	s.Nil(err)

--- a/chain/listener/mock/listener.go
+++ b/chain/listener/mock/listener.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	utils "github.com/ChainSafe/chainbridge-celo/utils"
+	types "github.com/ethereum/go-ethereum/core/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -110,16 +111,16 @@ func (m *MockValidatorsAggregator) EXPECT() *MockValidatorsAggregatorMockRecorde
 }
 
 // GetAPKForBlock mocks base method.
-func (m *MockValidatorsAggregator) GetAPKForBlock(block *big.Int, chainID uint8, epochSize uint64) ([]byte, error) {
+func (m *MockValidatorsAggregator) GetAPKForBlock(block *big.Int, chainID uint8, epochSize uint64, extra *types.IstanbulExtra) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAPKForBlock", block, chainID, epochSize)
+	ret := m.ctrl.Call(m, "GetAPKForBlock", block, chainID, epochSize, extra)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAPKForBlock indicates an expected call of GetAPKForBlock.
-func (mr *MockValidatorsAggregatorMockRecorder) GetAPKForBlock(block, chainID, epochSize interface{}) *gomock.Call {
+func (mr *MockValidatorsAggregatorMockRecorder) GetAPKForBlock(block, chainID, epochSize, extra interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPKForBlock", reflect.TypeOf((*MockValidatorsAggregator)(nil).GetAPKForBlock), block, chainID, epochSize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPKForBlock", reflect.TypeOf((*MockValidatorsAggregator)(nil).GetAPKForBlock), block, chainID, epochSize, extra)
 }

--- a/validatorsync/methods.go
+++ b/validatorsync/methods.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -47,9 +46,6 @@ func aggregatePublicKeys(validators []*istanbul.ValidatorData) (*bls.PublicKey, 
 		publicKeys[i] = validators[i].BLSPublicKey
 	}
 
-	log.Debug().Msgf("num public keys: %v", len(publicKeys))
-	log.Debug().Msgf("serialized public keys: %x", publicKeys)
-
 	publicKeyObjs := make([]*bls.PublicKey, len(publicKeys))
 	for i := range publicKeys {
 		publicKeyObj, err := bls.DeserializePublicKeyCached(publicKeys[i][:])
@@ -57,24 +53,15 @@ func aggregatePublicKeys(validators []*istanbul.ValidatorData) (*bls.PublicKey, 
 			return nil, err
 		}
 
-		// this changes each time
-		log.Debug().Msgf("public key obj: %v", publicKeyObj)
-
 		publicKeyObjs[i] = publicKeyObj
 		publicKeyObj.Destroy()
 	}
-
-	// as a result of the above, this also changes
-	log.Debug().Msgf("public key objs: %v", publicKeyObjs)
 
 	apk, err := bls.AggregatePublicKeys(publicKeyObjs)
 	if err != nil {
 		return nil, err
 	}
 	defer apk.Destroy()
-
-	// therefore, this will also change
-	log.Debug().Msgf("Returning APK: %v", apk)
 
 	return apk, nil
 }

--- a/validatorsync/methods.go
+++ b/validatorsync/methods.go
@@ -8,8 +8,9 @@ import (
 	"github.com/celo-org/celo-bls-go/bls"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto/bls"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -46,20 +47,34 @@ func aggregatePublicKeys(validators []*istanbul.ValidatorData) (*bls.PublicKey, 
 		publicKeys[i] = validators[i].BLSPublicKey
 	}
 
+	log.Debug().Msgf("num public keys: %v", len(publicKeys))
+	log.Debug().Msgf("serialized public keys: %x", publicKeys)
+
 	publicKeyObjs := make([]*bls.PublicKey, len(publicKeys))
 	for i := range publicKeys {
 		publicKeyObj, err := bls.DeserializePublicKeyCached(publicKeys[i][:])
 		if err != nil {
 			return nil, err
 		}
+
+		// this changes each time
+		log.Debug().Msgf("public key obj: %v", publicKeyObj)
+
 		publicKeyObjs[i] = publicKeyObj
 		publicKeyObj.Destroy()
 	}
+
+	// as a result of the above, this also changes
+	log.Debug().Msgf("public key objs: %v", publicKeyObjs)
+
 	apk, err := bls.AggregatePublicKeys(publicKeyObjs)
 	if err != nil {
 		return nil, err
 	}
 	defer apk.Destroy()
+
+	// therefore, this will also change
+	log.Debug().Msgf("Returning APK: %v", apk)
 
 	return apk, nil
 }

--- a/validatorsync/methods.go
+++ b/validatorsync/methods.go
@@ -71,3 +71,21 @@ func computeLastBlockOfEpochForProvidedBlock(block *big.Int, epochSize uint64) *
 	lastBlock := istanbul.GetEpochLastBlockNumber(epochNumber, epochSize)
 	return big.NewInt(0).SetUint64(lastBlock)
 }
+
+// filterValidatorsWithBitmap is a private function that returns a slice of
+// validators who signed the current block by applying the current
+// block's bitmap on a slice of validators chosen for the current epoch
+func filterValidatorsWithBitmap(validators []*istanbul.ValidatorData, bitmap *big.Int) []*istanbul.ValidatorData {
+	// init new slice to hold validators who signed block
+	newValidators := make([]*istanbul.ValidatorData, 0)
+
+	// iterate over validators in slice to determine which ones signed the block
+	for index, validator := range validators {
+		// if validator found within bitmap, append to new validators slice
+		if bitmap.Bit(index) == 1 {
+			newValidators = append(newValidators, &istanbul.ValidatorData{Address: validator.Address, BLSPublicKey: validator.BLSPublicKey})
+		}
+	}
+
+	return newValidators
+}

--- a/validatorsync/sync_test.go
+++ b/validatorsync/sync_test.go
@@ -4,18 +4,19 @@ package validatorsync
 
 import (
 	"errors"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/bls"
-	"github.com/ethereum/go-ethereum/rlp"
 	"math/big"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/ChainSafe/chainbridge-celo/validatorsync/mock"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	mock_validatorsync "github.com/ChainSafe/chainbridge-celo/validatorsync/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -125,7 +126,11 @@ func (s *SyncTestSuite) TestStoreBlockValidatorsWIthEmptyDB() {
 	s.Nil(err)
 	s.Equal(0, lb.Cmp(big.NewInt(24)))
 
-	apk, err := s.store.GetAPKForBlock(big.NewInt(1), chainID, 12)
+	// fetch Istanbul Extra data from block header
+	extra, err := types.ExtractIstanbulExtra(header)
+	s.Nil(err)
+
+	apk, err := s.store.GetAPKForBlock(big.NewInt(1), chainID, 12, extra)
 	s.Nil(err)
 	s.NotNil(apk)
 

--- a/validatorsync/sync_test.go
+++ b/validatorsync/sync_test.go
@@ -126,9 +126,26 @@ func (s *SyncTestSuite) TestStoreBlockValidatorsWIthEmptyDB() {
 	s.Nil(err)
 	s.Equal(0, lb.Cmp(big.NewInt(24)))
 
-	// fetch Istanbul Extra data from block header
-	extra, err := types.ExtractIstanbulExtra(header)
-	s.Nil(err)
+	// create custom Istanbul Extra data
+	extra := &types.IstanbulExtra{
+		AggregatedSeal: types.IstanbulAggregatedSeal{
+			// init bitmap at 0
+			Bitmap: big.NewInt(0),
+		},
+	}
+
+	// loop over vals4 to set bitmap
+	for valIndex := range vals4 {
+		// set that validators 5 (index 4) and 6 (index 5) did not sign block
+		if valIndex == 4 || valIndex == 5 {
+			// skip
+			continue
+		}
+		// set bitmap
+		extra.AggregatedSeal.Bitmap.SetBit(
+			extra.AggregatedSeal.Bitmap, valIndex, 1,
+		)
+	}
 
 	apk, err := s.store.GetAPKForBlock(big.NewInt(1), chainID, 12, extra)
 	s.Nil(err)

--- a/validatorsync/syncerstorr.go
+++ b/validatorsync/syncerstorr.go
@@ -134,23 +134,15 @@ func (db *ValidatorsStore) GetAPKForBlock(block *big.Int, chainID uint8, epochSi
 			return nil, err
 		}
 
-		// make new slice to determine which validators (keys) signed the block
-		bitmaskedValidators := make([]*istanbul.ValidatorData, 0)
+		log.Debug().Msgf("validators: %v", vals)
 
-		log.Debug().Msgf("bitmap: %v", extra.AggregatedSeal.Bitmap)
+		// apply bitmask on validators slice
+		newValidators := filterValidatorsWithBitmap(vals, extra.AggregatedSeal.Bitmap)
 
-		// if signed the block, add to block signed validators slice
-		for index, val := range vals {
-			log.Debug().Msgf("bitmap of [%d]: %d", index, extra.AggregatedSeal.Bitmap.Bit(index))
-			if extra.AggregatedSeal.Bitmap.Bit(index) == 1 {
-				bitmaskedValidators = append(bitmaskedValidators, val)
-			}
-		}
+		// if signed the block, add to block signe validators slice
+		log.Debug().Msgf("vals: %v", len(newValidators))
 
-		log.Debug().Msgf("vals: %v", len(bitmaskedValidators))
-		log.Debug().Msgf("val address: %x", bitmaskedValidators[i].Address)
-
-		pk, err := aggregatePublicKeys(bitmaskedValidators)
+		pk, err := aggregatePublicKeys(newValidators)
 		if err != nil {
 			return nil, err
 		}

--- a/validatorsync/syncerstorr.go
+++ b/validatorsync/syncerstorr.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/rs/zerolog/log"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -134,13 +133,8 @@ func (db *ValidatorsStore) GetAPKForBlock(block *big.Int, chainID uint8, epochSi
 			return nil, err
 		}
 
-		log.Debug().Msgf("validators: %v", vals)
-
 		// apply bitmask on validators slice
 		newValidators := filterValidatorsWithBitmap(vals, extra.AggregatedSeal.Bitmap)
-
-		// if signed the block, add to block signe validators slice
-		log.Debug().Msgf("vals: %v", len(newValidators))
 
 		pk, err := aggregatePublicKeys(newValidators)
 		if err != nil {

--- a/validatorsync/syncerstorr.go
+++ b/validatorsync/syncerstorr.go
@@ -128,8 +128,7 @@ func (db *ValidatorsStore) GetAPKForBlock(block *big.Int, chainID uint8, epochSi
 	bitmaskedValidators := make([]*istanbul.ValidatorData, 0)
 
 	for i := 0; i <= 10; i++ {
-		// vals, err := db.GetValidatorsForBlock(computeLastBlockOfEpochForProvidedBlock(block, epochSize), chainID)
-		vals, err := db.GetValidatorsForBlock(block, chainID)
+		vals, err := db.GetValidatorsForBlock(computeLastBlockOfEpochForProvidedBlock(block, epochSize), chainID)
 		if err != nil {
 			if errors.Is(err, leveldb.ErrNotFound) {
 				time.Sleep(5 * time.Second)
@@ -150,7 +149,14 @@ func (db *ValidatorsStore) GetAPKForBlock(block *big.Int, chainID uint8, epochSi
 		if err != nil {
 			return nil, err
 		}
-		log.Debug().Msgf("pk: %x", pk)
+
+		pkSerialized, err := pk.Serialize()
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debug().Msgf("serialized pk: %x", pkSerialized)
+
 		return pk.Serialize()
 	}
 	return nil, ErrNoBlockInStore

--- a/validatorsync/syncerstorr_test.go
+++ b/validatorsync/syncerstorr_test.go
@@ -133,10 +133,28 @@ func (s *SyncerDBTestSuite) TestGetAPKForBlock() {
 
 	err := s.syncer.SetValidatorsForBlock(big.NewInt(12), startVals, chainID)
 	s.Nil(err)
-	header, err := generateBlockHeader()
-	s.Nil(err)
-	extra, err := types.ExtractIstanbulExtra(header)
-	s.Nil(err)
+
+	// create custom Istanbul Extra data
+	extra := &types.IstanbulExtra{
+		AggregatedSeal: types.IstanbulAggregatedSeal{
+			// init bitmap at 0
+			Bitmap: big.NewInt(0),
+		},
+	}
+
+	// loop over vals4 to set bitmap
+	for valIndex := range startVals {
+		// set that validator 1 (index 0) did not sign block
+		if valIndex == 0 {
+			// skip
+			continue
+		}
+		// set bitmap
+		extra.AggregatedSeal.Bitmap.SetBit(
+			extra.AggregatedSeal.Bitmap, valIndex, 1,
+		)
+	}
+
 	apk, err := s.syncer.GetAPKForBlock(big.NewInt(11), chainID, 12, extra)
 	s.Nil(err)
 	s.NotNil(apk)

--- a/validatorsync/syncerstorr_test.go
+++ b/validatorsync/syncerstorr_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/stretchr/testify/suite"
@@ -132,7 +133,11 @@ func (s *SyncerDBTestSuite) TestGetAPKForBlock() {
 
 	err := s.syncer.SetValidatorsForBlock(big.NewInt(12), startVals, chainID)
 	s.Nil(err)
-	apk, err := s.syncer.GetAPKForBlock(big.NewInt(11), chainID, 12)
+	header, err := generateBlockHeader()
+	s.Nil(err)
+	extra, err := types.ExtractIstanbulExtra(header)
+	s.Nil(err)
+	apk, err := s.syncer.GetAPKForBlock(big.NewInt(11), chainID, 12, extra)
 	s.Nil(err)
 	s.NotNil(apk)
 }
@@ -145,7 +150,11 @@ func (s *SyncerDBTestSuite) TestGetAPKForBlockNotExistsBlockErr() {
 	startVals[2] = &istanbul.ValidatorData{Address: common.Address{0x2f}, BLSPublicKey: blscrypto.SerializedPublicKey{}}
 	err := s.syncer.SetValidatorsForBlock(big.NewInt(12), startVals, chainID)
 	s.Nil(err)
-	apk, err := s.syncer.GetAPKForBlock(big.NewInt(11), chainID, 13)
+	header, err := generateBlockHeader()
+	s.Nil(err)
+	extra, err := types.ExtractIstanbulExtra(header)
+	s.Nil(err)
+	apk, err := s.syncer.GetAPKForBlock(big.NewInt(11), chainID, 13, extra)
 	s.NotNil(err)
 	s.True(errors.Is(err, ErrNoBlockInStore))
 	s.Nil(apk)

--- a/validatorsync/syncerstorr_test.go
+++ b/validatorsync/syncerstorr_test.go
@@ -142,7 +142,7 @@ func (s *SyncerDBTestSuite) TestGetAPKForBlock() {
 		},
 	}
 
-	// loop over vals4 to set bitmap
+	// loop over startVals to set bitmap
 	for valIndex := range startVals {
 		// set that validator 1 (index 0) did not sign block
 		if valIndex == 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As explained in the related issue, the current APK (aggregated public key) is constructed by pulling in validator data from the validators who were selected for the current epoch, taking their public keys, then aggregating them.

Instead, the APK should be constructed by fetching all validators from the pool of validators for the epoch and then applying the bitmap included in the Istanbul extra data stored within the block header against this validator list. Once this filtering is done, then can the APK be constructed to appropriately represent the block that was verified.

This resulting list of validators will be only the validators who signed the block, rather than the entire pool of validators who were selected for the epoch.

---
### Note:
- `chain/listener/listener.go` has code added for debugging purposes
- `validatorsync/syncerstorr.go` also has some logs added for debugging purposes
- `validatorsync/syncerstorr_test.go` needed an additional argument because of the change to `GetAPKForBlock`
- `validatorsync/sync_test.go` needed an additional argument because of the change to `GetAPKForBlock`

_The additions to the `syncerstorr_test` and `sync_test` did not themselves break the tests; the tests were found to be failing prior to the change. This is being investigated_

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #116 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were written.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
